### PR TITLE
Adds the ability to toggle spawning of the controllers

### DIFF
--- a/launch/move_group.launch
+++ b/launch/move_group.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="load_gripper" default="true" />
+  <arg name="spawn_controllers" default="true" />
 
   <include file="$(find panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_gripper" value="$(arg load_gripper)" />
@@ -37,7 +38,7 @@
     <arg name="moveit_controller_manager" value="panda" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
   </include>
-  <include file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
+  <include if="$(arg spawn_controllers)" file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find panda_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
@@ -53,20 +54,20 @@
     <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-    <!-- load these non-default MoveGroup capabilities -->	
-    <!--	
-    <param name="capabilities" value="	
-                  a_package/AwsomeMotionPlanningCapability	
-                  another_package/GraspPlanningPipeline	
-                  " />	
-    -->	
+    <!-- load these non-default MoveGroup capabilities -->
+    <!--
+    <param name="capabilities" value="
+                  a_package/AwsomeMotionPlanningCapability
+                  another_package/GraspPlanningPipeline
+                  " />
+    -->
 
-    <!-- inhibit these default MoveGroup capabilities -->	
-    <!--	
-    <param name="disable_capabilities" value="	
-                  move_group/MoveGroupKinematicsService	
-                  move_group/ClearOctomapService	
-                  " />	
+    <!-- inhibit these default MoveGroup capabilities -->
+    <!--
+    <param name="disable_capabilities" value="
+                  move_group/MoveGroupKinematicsService
+                  move_group/ClearOctomapService
+                  " />
     -->
 
 


### PR DESCRIPTION
This commit gives users the ability to turn spawning of the controllers on and off. This allows users to load and spawn controllers outside of the move_group.launch file. It is related to #5 but here the gazebo controller PID gains are always loaded.

For me this pull request together with https://github.com/tahsinkose/franka_ros/pull/1 allows me to use the `EffortJointInterface` hardware interface instead of the `PositionJointInterface`.
