### PR TITLE
Adds the ability to toggle spawning of the controllers (solution 2)

### DIFF
--- a/launch/move_group.launch
+++ b/launch/move_group.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="load_gripper" default="true" />
+  <arg name="spawn_controllers" default="true" />
 
   <include file="$(find panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_gripper" value="$(arg load_gripper)" />
@@ -36,8 +37,8 @@
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="panda" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
+    <arg name="spawn_controllers" value="$(arg spawn_controllers)"/>
   </include>
-  <include file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find panda_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
@@ -53,20 +54,20 @@
     <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-    <!-- load these non-default MoveGroup capabilities -->	
-    <!--	
-    <param name="capabilities" value="	
-                  a_package/AwsomeMotionPlanningCapability	
-                  another_package/GraspPlanningPipeline	
-                  " />	
-    -->	
+    <!-- load these non-default MoveGroup capabilities -->
+    <!--
+    <param name="capabilities" value="
+                  a_package/AwsomeMotionPlanningCapability
+                  another_package/GraspPlanningPipeline
+                  " />
+    -->
 
-    <!-- inhibit these default MoveGroup capabilities -->	
-    <!--	
-    <param name="disable_capabilities" value="	
-                  move_group/MoveGroupKinematicsService	
-                  move_group/ClearOctomapService	
-                  " />	
+    <!-- inhibit these default MoveGroup capabilities -->
+    <!--
+    <param name="disable_capabilities" value="
+                  move_group/MoveGroupKinematicsService
+                  move_group/ClearOctomapService
+                  " />
     -->
 
 

--- a/launch/trajectory_execution.launch.xml
+++ b/launch/trajectory_execution.launch.xml
@@ -1,6 +1,6 @@
 <launch>
-
-  <!-- This file makes it easy to include the settings for trajectory execution  -->  
+  <arg name="spawn_controllers" default="true" />
+  <!-- This file makes it easy to include the settings for trajectory execution  -->
 
   <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>
@@ -12,9 +12,10 @@
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
-  
+
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="panda" />
   <include file="$(find panda_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />
-  
+  <include if="$(arg spawn_controllers)" file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
+
 </launch>


### PR DESCRIPTION
This commit gives users the ability to turn spawning of the controllers on and off. This allows users to load and spawn controllers outside of the move_group.launch file.